### PR TITLE
Two more fixes:

### DIFF
--- a/src/AspireMobile.SettingsGenerator/GenerateSettings.cs
+++ b/src/AspireMobile.SettingsGenerator/GenerateSettings.cs
@@ -65,7 +65,7 @@ public class GenerateSettings
                     if (variableName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                     {
                         settings.Add(new Setting(variableName, value));
-                        variableName = variableName.Substring(variableName.Length);
+                        variableName = variableName.Substring(prefix.Length);
                         break;
                     }
                 }

--- a/src/MauiAspire.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MauiProgram.cs
+++ b/src/MauiAspire.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MauiProgram.cs
@@ -1,5 +1,4 @@
-﻿using MauiAspire.App;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
- Fix generated setting name to properly remove just prefix
- Remove MauiApp using in template, as it's now obsolete.