### PR TITLE
Remove appsettings reference from MAUI template app

### DIFF
--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AspireStarterApplication.1.csproj
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AspireStarterApplication.1.csproj
@@ -56,15 +56,6 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<None Remove="appsettings.json;appsettings.*.json" />
-		<Content Include="appsettings.json;appsettings.*.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-		</Content>
-	</ItemGroup>
-
 	<PropertyGroup>
 		<MauiVersion>8.0.6</MauiVersion>
 	</PropertyGroup>


### PR DESCRIPTION
The appsettings files themselves were removed before, but the reference in the csproj also needs to be removed.

Fixes #28 