### PR TITLE
Bump to GA version of Aspire dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <PackageVersion Include="Aspire.Hosting" Version="8.0.0-preview.6.24214.1" />
+    <PackageVersion Include="Aspire.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>

--- a/src/AspireMaui.ProjectTemplates/AspireMaui.ProjectTemplates.csproj
+++ b/src/AspireMaui.ProjectTemplates/AspireMaui.ProjectTemplates.csproj
@@ -13,7 +13,7 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Description>.NET MAUI Aspire Template Pack for Microsoft Template Engine</Description>
-    <AspireVersion>8.0.0-preview.6.24214.1</AspireVersion>
+    <AspireVersion>8.0.1</AspireVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
@@ -13,10 +13,9 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_ASPIRE_VERSION!!" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -54,7 +54,8 @@ public static class Extensions
                 }
 
                 tracing.AddAspNetCoreInstrumentation()
-                       .AddGrpcClientInstrumentation()
+                        // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                       //.AddGrpcClientInstrumentation()
                        .AddHttpClientInstrumentation();
             });
 

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AppDefaultsExtensions.cs
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AppDefaultsExtensions.cs
@@ -47,7 +47,9 @@ public static class AppDefaultsExtensions
                     tracing.SetSampler(new AlwaysOnSampler());
                 }
 
-                tracing.AddGrpcClientInstrumentation()
+                tracing
+                       // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                       //.AddGrpcClientInstrumentation()
                        .AddHttpClientInstrumentation();
             });
 

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AspireStarterApplication.1.csproj
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/AspireStarterApplication.1.csproj
@@ -71,9 +71,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_ASPIRE_VERSION!!" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     </ItemGroup>


### PR DESCRIPTION
Also remove use of GrpcClientInstrumentation by default, matching the change in Aspire itself to no longer include it in the templates.