### PR TITLE
More template updates, including OpenTelemetry trace/metrics support

### DIFF
--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MainPage.xaml.cs
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MainPage.xaml.cs
@@ -37,7 +37,7 @@ public partial class MainPage : ContentPage
                 throw new InvalidOperationException("Forced error!");
             }
 
-            var weather = await _weatherApiClient.GetWeatherAsync(_closingCts.Token);
+            var weather = await _weatherApiClient.GetWeatherAsync(cancellationToken:_closingCts.Token);
             dgWeather.ItemsSource = weather;
             dgWeather.IsVisible = true;
         }

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MauiProgram.cs
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/MauiProgram.cs
@@ -36,6 +36,8 @@ public static class MauiProgram
         mauiAppBuilder.Services.AddHttpClient<WeatherApiClient>(client => client.BaseAddress = new($"{scheme}://apiservice"));
         mauiAppBuilder.Services.AddSingleton<MainPage>();
 
-        return mauiAppBuilder.Build();
+        MauiApp mauiApp = mauiAppBuilder.Build();
+        mauiApp.InitOpenTelemetryServices();
+        return mauiApp;
     }
 }

--- a/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/WeatherApiClient.cs
+++ b/src/AspireMaui.ProjectTemplates/templates/maui-aspire/AspireStarterApplication.1/WeatherApiClient.cs
@@ -4,9 +4,24 @@ namespace AspireStarterApplication._1;
 
 public class WeatherApiClient(HttpClient httpClient)
 {
-    public async Task<WeatherForecast[]> GetWeatherAsync(CancellationToken cancellationToken = default)
+    public async Task<WeatherForecast[]> GetWeatherAsync(int maxItems = 10, CancellationToken cancellationToken = default)
     {
-        return await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast", cancellationToken) ?? [];
+        List<WeatherForecast>? forecasts = null;
+
+        await foreach (var forecast in httpClient.GetFromJsonAsAsyncEnumerable<WeatherForecast>("/weatherforecast", cancellationToken))
+        {
+            if (forecasts?.Count >= maxItems)
+            {
+                break;
+            }
+            if (forecast is not null)
+            {
+                forecasts ??= [];
+                forecasts.Add(forecast);
+            }
+        }
+
+        return forecasts?.ToArray() ?? [];
     }
 }
 


### PR DESCRIPTION
Make a few other template updates, based on the Aspire GA template.

Also add in support so that OpenTelemetry trace and metrics work. The code here is key: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs Since MAUI apps don't support IHostedService and don't call TelemetryHostedService.StartAsync, we just do what this service does, getting the 3 required OpenTelemetry services to initialize them.